### PR TITLE
Add missing notification channels in the UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ OpenSearch Dashboards Reports allows ‘Report Owner’ (engineers, including bu
 
 ## Documentation & Forum
 
-Please see our technical [documentation](https://docs.opensearch.org/latest/reporting/report-dashboard-index/) to learn more about its features. For additional help with the plugin, including questions about opening an issue, try the OpenSearch [Forum](https://forum.opensearch.org/c/opensearch-dashboards/reports/51).
+Please see our technical [documentation](https://docs.opensearch.org/3.1/reporting/report-dashboard-index/) to learn more about its features. For additional help with the plugin, including questions about opening an issue, try the OpenSearch [Forum](https://forum.opensearch.org/c/opensearch-dashboards/reports/51).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ OpenSearch Dashboards Reports allows ‘Report Owner’ (engineers, including bu
 
 ## Documentation & Forum
 
-Please see our technical [documentation](https://opensearch.org/docs/dashboards/reporting/) to learn more about its features. For additional help with the plugin, including questions about opening an issue, try the OpenSearch [Forum](https://forum.opensearch.org/c/opensearch-dashboards/reports/51).
+Please see our technical [documentation](https://docs.opensearch.org/latest/reporting/report-dashboard-index/) to learn more about its features. For additional help with the plugin, including questions about opening an issue, try the OpenSearch [Forum](https://forum.opensearch.org/c/opensearch-dashboards/reports/51).
 
 ## Contributing
 

--- a/public/components/main/__tests__/__snapshots__/main.test.tsx.snap
+++ b/public/components/main/__tests__/__snapshots__/main.test.tsx.snap
@@ -447,7 +447,7 @@ exports[`<Main /> panel render component 1`] = `
                                  
                                 <a
                                   class="euiLink euiLink--primary"
-                                  href="https://docs.opensearch.org/latest/reporting/report-dashboard-index/"
+                                  href="https://docs.opensearch.org/3.1/reporting/report-dashboard-index/"
                                   rel="noopener noreferrer"
                                   target="_blank"
                                 >
@@ -900,7 +900,7 @@ exports[`<Main /> panel render component 1`] = `
                                    
                                   <a
                                     class="euiLink euiLink--primary"
-                                    href="https://docs.opensearch.org/latest/reporting/report-dashboard-index/"
+                                    href="https://docs.opensearch.org/3.1/reporting/report-dashboard-index/"
                                     rel="noopener noreferrer"
                                     target="_blank"
                                   >
@@ -1419,7 +1419,7 @@ exports[`<Main /> panel render component after create success 1`] = `
                                  
                                 <a
                                   class="euiLink euiLink--primary"
-                                  href="https://docs.opensearch.org/latest/reporting/report-dashboard-index/"
+                                  href="https://docs.opensearch.org/3.1/reporting/report-dashboard-index/"
                                   rel="noopener noreferrer"
                                   target="_blank"
                                 >
@@ -1872,7 +1872,7 @@ exports[`<Main /> panel render component after create success 1`] = `
                                    
                                   <a
                                     class="euiLink euiLink--primary"
-                                    href="https://docs.opensearch.org/latest/reporting/report-dashboard-index/"
+                                    href="https://docs.opensearch.org/3.1/reporting/report-dashboard-index/"
                                     rel="noopener noreferrer"
                                     target="_blank"
                                   >
@@ -2447,7 +2447,7 @@ exports[`<Main /> panel render component after delete success 1`] = `
                                  
                                 <a
                                   class="euiLink euiLink--primary"
-                                  href="https://docs.opensearch.org/latest/reporting/report-dashboard-index/"
+                                  href="https://docs.opensearch.org/3.1/reporting/report-dashboard-index/"
                                   rel="noopener noreferrer"
                                   target="_blank"
                                 >
@@ -2900,7 +2900,7 @@ exports[`<Main /> panel render component after delete success 1`] = `
                                    
                                   <a
                                     class="euiLink euiLink--primary"
-                                    href="https://docs.opensearch.org/latest/reporting/report-dashboard-index/"
+                                    href="https://docs.opensearch.org/3.1/reporting/report-dashboard-index/"
                                     rel="noopener noreferrer"
                                     target="_blank"
                                   >
@@ -3476,7 +3476,7 @@ exports[`<Main /> panel render component after edit success 1`] = `
                                  
                                 <a
                                   class="euiLink euiLink--primary"
-                                  href="https://docs.opensearch.org/latest/reporting/report-dashboard-index/"
+                                  href="https://docs.opensearch.org/3.1/reporting/report-dashboard-index/"
                                   rel="noopener noreferrer"
                                   target="_blank"
                                 >
@@ -3929,7 +3929,7 @@ exports[`<Main /> panel render component after edit success 1`] = `
                                    
                                   <a
                                     class="euiLink euiLink--primary"
-                                    href="https://docs.opensearch.org/latest/reporting/report-dashboard-index/"
+                                    href="https://docs.opensearch.org/3.1/reporting/report-dashboard-index/"
                                     rel="noopener noreferrer"
                                     target="_blank"
                                   >

--- a/public/components/main/__tests__/__snapshots__/main.test.tsx.snap
+++ b/public/components/main/__tests__/__snapshots__/main.test.tsx.snap
@@ -447,7 +447,7 @@ exports[`<Main /> panel render component 1`] = `
                                  
                                 <a
                                   class="euiLink euiLink--primary"
-                                  href="https://opensearch.org/docs/dashboards/reporting/"
+                                  href="https://docs.opensearch.org/latest/reporting/report-dashboard-index/"
                                   rel="noopener noreferrer"
                                   target="_blank"
                                 >
@@ -900,7 +900,7 @@ exports[`<Main /> panel render component 1`] = `
                                    
                                   <a
                                     class="euiLink euiLink--primary"
-                                    href="https://opensearch.org/docs/dashboards/reporting/"
+                                    href="https://docs.opensearch.org/latest/reporting/report-dashboard-index/"
                                     rel="noopener noreferrer"
                                     target="_blank"
                                   >
@@ -1419,7 +1419,7 @@ exports[`<Main /> panel render component after create success 1`] = `
                                  
                                 <a
                                   class="euiLink euiLink--primary"
-                                  href="https://opensearch.org/docs/dashboards/reporting/"
+                                  href="https://docs.opensearch.org/latest/reporting/report-dashboard-index/"
                                   rel="noopener noreferrer"
                                   target="_blank"
                                 >
@@ -1872,7 +1872,7 @@ exports[`<Main /> panel render component after create success 1`] = `
                                    
                                   <a
                                     class="euiLink euiLink--primary"
-                                    href="https://opensearch.org/docs/dashboards/reporting/"
+                                    href="https://docs.opensearch.org/latest/reporting/report-dashboard-index/"
                                     rel="noopener noreferrer"
                                     target="_blank"
                                   >
@@ -2447,7 +2447,7 @@ exports[`<Main /> panel render component after delete success 1`] = `
                                  
                                 <a
                                   class="euiLink euiLink--primary"
-                                  href="https://opensearch.org/docs/dashboards/reporting/"
+                                  href="https://docs.opensearch.org/latest/reporting/report-dashboard-index/"
                                   rel="noopener noreferrer"
                                   target="_blank"
                                 >
@@ -2900,7 +2900,7 @@ exports[`<Main /> panel render component after delete success 1`] = `
                                    
                                   <a
                                     class="euiLink euiLink--primary"
-                                    href="https://opensearch.org/docs/dashboards/reporting/"
+                                    href="https://docs.opensearch.org/latest/reporting/report-dashboard-index/"
                                     rel="noopener noreferrer"
                                     target="_blank"
                                   >
@@ -3476,7 +3476,7 @@ exports[`<Main /> panel render component after edit success 1`] = `
                                  
                                 <a
                                   class="euiLink euiLink--primary"
-                                  href="https://opensearch.org/docs/dashboards/reporting/"
+                                  href="https://docs.opensearch.org/latest/reporting/report-dashboard-index/"
                                   rel="noopener noreferrer"
                                   target="_blank"
                                 >
@@ -3929,7 +3929,7 @@ exports[`<Main /> panel render component after edit success 1`] = `
                                    
                                   <a
                                     class="euiLink euiLink--primary"
-                                    href="https://opensearch.org/docs/dashboards/reporting/"
+                                    href="https://docs.opensearch.org/latest/reporting/report-dashboard-index/"
                                     rel="noopener noreferrer"
                                     target="_blank"
                                   >

--- a/public/components/main/__tests__/__snapshots__/report_definitions_table.test.tsx.snap
+++ b/public/components/main/__tests__/__snapshots__/report_definitions_table.test.tsx.snap
@@ -987,7 +987,7 @@ exports[`<ReportDefinitions /> panel render empty table 1`] = `
                                
                               <a
                                 class="euiLink euiLink--primary"
-                                href="https://opensearch.org/docs/dashboards/reporting/"
+                                href="https://docs.opensearch.org/latest/reporting/report-dashboard-index/"
                                 rel="noopener noreferrer"
                                 target="_blank"
                               >

--- a/public/components/main/__tests__/__snapshots__/report_definitions_table.test.tsx.snap
+++ b/public/components/main/__tests__/__snapshots__/report_definitions_table.test.tsx.snap
@@ -987,7 +987,7 @@ exports[`<ReportDefinitions /> panel render empty table 1`] = `
                                
                               <a
                                 class="euiLink euiLink--primary"
-                                href="https://docs.opensearch.org/latest/reporting/report-dashboard-index/"
+                                href="https://docs.opensearch.org/3.1/reporting/report-dashboard-index/"
                                 rel="noopener noreferrer"
                                 target="_blank"
                               >

--- a/public/components/main/__tests__/__snapshots__/reports_table.test.tsx.snap
+++ b/public/components/main/__tests__/__snapshots__/reports_table.test.tsx.snap
@@ -1005,7 +1005,7 @@ exports[`<ReportsTable /> panel render empty component 1`] = `
                              
                             <a
                               class="euiLink euiLink--primary"
-                              href="https://docs.opensearch.org/latest/reporting/report-dashboard-index/"
+                              href="https://docs.opensearch.org/3.1/reporting/report-dashboard-index/"
                               rel="noopener noreferrer"
                               target="_blank"
                             >

--- a/public/components/main/__tests__/__snapshots__/reports_table.test.tsx.snap
+++ b/public/components/main/__tests__/__snapshots__/reports_table.test.tsx.snap
@@ -1005,7 +1005,7 @@ exports[`<ReportsTable /> panel render empty component 1`] = `
                              
                             <a
                               class="euiLink euiLink--primary"
-                              href="https://opensearch.org/docs/dashboards/reporting/"
+                              href="https://docs.opensearch.org/latest/reporting/report-dashboard-index/"
                               rel="noopener noreferrer"
                               target="_blank"
                             >

--- a/public/components/main/report_definition_details/report_definition_details.tsx
+++ b/public/components/main/report_definition_details/report_definition_details.tsx
@@ -458,13 +458,8 @@ export function ReportDefinitionDetails(props: {
     };
 
     if (delivery.configIds.length > 0) {
-      const [
-        {
-          config: { name },
-        },
-      ] = await getConfigChannel(delivery.configIds);
-
-      reportDefinitionDetailsMetaData.channelName = name;
+      const configsChannels = await getConfigChannel(delivery.configIds);
+      reportDefinitionDetailsMetaData.channelName = configsChannels.map((channel) => channel.config.name).join(', ');
     }
     return reportDefinitionDetailsMetaData;
   };
@@ -702,14 +697,63 @@ export function ReportDefinitionDetails(props: {
     <GenerateReportLoadingModal setShowLoading={setShowLoading} />
   ) : null;
 
-  const getConfigChannel = async (idChannels) => {
-    const { httpClient } = props;
-    const configId = idChannels[0];
-    const { config_list: configList } = await httpClient.get(
-      `${REPORTING_NOTIFICATIONS_DASHBOARDS_API.GET_CONFIG}/${configId}`
+const addToast = (toast: any) => {
+  setToasts(toasts.concat(toast));
+};
+
+const getConfigChannel = async (idChannels: string[]): Promise<any[]> => {
+  const { httpClient } = props;
+
+  if (!idChannels?.length) {
+    return [];
+  }
+
+  try {
+    const results = await Promise.allSettled(
+      idChannels.map(async (id) => {
+        const { config_list: configList } = await httpClient.get(
+          `${REPORTING_NOTIFICATIONS_DASHBOARDS_API.GET_CONFIG}/${id}`
+        );
+        return configList;
+      })
     );
-    return configList;
-  };
+    const successfulConfigs = results
+      .filter((result): result is PromiseFulfilledResult<any> => 
+        result.status === 'fulfilled'
+      )
+      .map(result => result.value)
+      .flat();
+
+    const failedResults = results
+      .map((result, index) => ({ result, id: idChannels[index] }))
+      .filter(({ result }) => result.status === 'rejected');
+
+    if (failedResults.length > 0) {
+      addToast({
+        title: i18n.translate(
+          'opensearch.reports.reportDefinitionsDetails.toast.failedChannelConfigs',
+          { defaultMessage: 'Failed to fetch some channel configs.' }
+        ),
+        color: 'danger',
+        iconType: 'alert',
+        id: 'failedChannelConfigsToast',
+        text: `${failedResults.map(({ id, result }) => `ID: ${id}, Error: ${result.reason}`).join(', ')}`,
+      })
+    }
+    return successfulConfigs;
+  } catch (error) {
+    addToast({
+      title: i18n.translate(
+        'opensearch.reports.reportDefinitionsDetails.toast.errorFetchingChannelConfigs',
+        { defaultMessage: 'Error fetching channel configs.' }
+      ),
+      color: 'danger',
+      iconType: 'alert',
+      id: 'errorFetchingChannelConfigsToast',
+      text: error.message || 'Unknown error occurred'
+    });
+  }
+};
 
   const notificationSection = (
     <EuiFlexGroup>

--- a/public/components/main/report_definitions_table.tsx
+++ b/public/components/main/report_definitions_table.tsx
@@ -13,6 +13,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { humanReadableDate } from './main_utils';
+import { versionOpensearchShort } from '../utils/utils';
 
 const emptyMessageReportDefinitions = (
   <EuiEmptyPrompt
@@ -39,7 +40,8 @@ const emptyMessageReportDefinitions = (
             { defaultMessage: 'To learn more, see' }
           )}{' '}
           <EuiLink
-            href="https://docs.opensearch.org/latest/reporting/report-dashboard-index/"
+            // Wazuh: If OpenSearch fix the link, remove this comment and use their link
+            href={`https://docs.opensearch.org/${versionOpensearchShort}/reporting/report-dashboard-index/`}
             target="_blank"
           >
             {i18n.translate(

--- a/public/components/main/report_definitions_table.tsx
+++ b/public/components/main/report_definitions_table.tsx
@@ -39,7 +39,7 @@ const emptyMessageReportDefinitions = (
             { defaultMessage: 'To learn more, see' }
           )}{' '}
           <EuiLink
-            href="https://opensearch.org/docs/dashboards/reporting/"
+            href="https://docs.opensearch.org/latest/reporting/report-dashboard-index/"
             target="_blank"
           >
             {i18n.translate(

--- a/public/components/main/reports_table.tsx
+++ b/public/components/main/reports_table.tsx
@@ -57,7 +57,7 @@ const emptyMessageReports = (
             { defaultMessage: 'To learn more, see' }
           )}{' '}
           <EuiLink
-            href="https://opensearch.org/docs/dashboards/reporting/"
+            href="https://docs.opensearch.org/latest/reporting/report-dashboard-index/"
             target="_blank"
           >
             {i18n.translate(

--- a/public/components/main/reports_table.tsx
+++ b/public/components/main/reports_table.tsx
@@ -19,6 +19,7 @@ import {
   generateReportById,
 } from './main_utils';
 import { GenerateReportLoadingModal } from './loading_modal';
+import { versionOpensearchShort } from '../utils/utils';
 
 const reportStatusOptions = [
   'Created',
@@ -57,7 +58,8 @@ const emptyMessageReports = (
             { defaultMessage: 'To learn more, see' }
           )}{' '}
           <EuiLink
-            href="https://docs.opensearch.org/latest/reporting/report-dashboard-index/"
+            // Wazuh: If OpenSearch fix the link, remove this comment and use their link
+            href={`https://docs.opensearch.org/${versionOpensearchShort}/reporting/report-dashboard-index/`}
             target="_blank"
           >
             {i18n.translate(

--- a/public/components/utils/utils.tsx
+++ b/public/components/utils/utils.tsx
@@ -4,6 +4,7 @@
  */
 
 import React from 'react';
+import { version } from '../../../package.json';
 
 export const permissionsMissingToast = (action: string) => {
   return {
@@ -27,5 +28,8 @@ export const permissionsMissingActions = {
   UPDATING_DEFINITION: 'updating report definition',
   CREATING_REPORT_DEFINITION: 'creating new report definition.',
 };
+
+// Wazuh: If OpenSearch fix the link, remove this comment and remove the export
+export const versionOpensearchShort = version.split('.').splice(0, 2).join('.');
 
 export const timeRangeMatcher = /time:\(from:(.+?),to:(.+?)\)/;

--- a/public/components/utils/utils.tsx
+++ b/public/components/utils/utils.tsx
@@ -13,7 +13,10 @@ export const permissionsMissingToast = (action: string) => {
     iconType: 'alert',
     id: 'permissionsMissingErrorToast' + action.replace(' ', ''),
     text: (
-      <p>Insufficient permissions. Reach out to your OpenSearch Dashboards administrator.</p>
+      <p>
+        Insufficient permissions. Reach out to your OpenSearch Dashboards
+        administrator.
+      </p>
     ),
   };
 };


### PR DESCRIPTION
### Description

It was explicitly set to only ask for the information of the channel that was in position 0, it was changed to look for the information of all the channels configured in the report so that all the configured channels appear in the description of the report.

### Issues Resolved

- #47 

### Screenshot

<img width="1542" height="1170" alt="image" src="https://github.com/user-attachments/assets/9a5b379f-c1f1-487f-a7b6-0aea011e314d" />

### Test

1. Configure 2 or more channels in the notification plugin
2. Create a report and add the 2 or more channels created above
3. Go to the detail of the report created, you should see all the channels that were added

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

